### PR TITLE
Changed: port to python3.11 and pytest-html v4

### DIFF
--- a/pytest_html_object_storage/plugin.py
+++ b/pytest_html_object_storage/plugin.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
@@ -20,8 +21,15 @@ def pytest_addoption(parser: Parser):
     )
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_configure(config: Config):
     if config.getoption("--store-minio") and not hasattr(config, "workerinput"):
+        if not (
+            config.getoption("--html") and config.getoption("--self-contained-html")
+        ):
+            raise Exception(
+                """ You must configure pytest-hmtl to generate a self-contained report "--html=<path_to_the_report>" and "--self-contained-html" """
+            )
         if (
             not os.environ.get("OBJECT_STORAGE_ENDPOINT")
             or not os.environ.get("OBJECT_STORAGE_BUCKET")
@@ -32,9 +40,15 @@ def pytest_configure(config: Config):
                 "You must set the environment variables for html_minio plugin"
             )
         config._html_minio = HTMLMinio(config)
-        config.pluginmanager.register(config._html_minio)
+        config.pluginmanager.register(config._html_minio, "pytest-html-object-storage")
 
     if config.getoption("--store-swift") and not hasattr(config, "workerinput"):
+        if not (
+            config.getoption("--html") and config.getoption("--self-contained-html")
+        ):
+            raise Exception(
+                """ You must configure pytest-hmtl to generate a self-contained report "--html" and "--self-contained-html"""
+            )
         if (
             not os.environ.get("OBJECT_STORAGE_ENDPOINT")
             or not os.environ.get("OBJECT_STORAGE_BUCKET")

--- a/pytest_html_object_storage/swift.py
+++ b/pytest_html_object_storage/swift.py
@@ -50,7 +50,7 @@ class HTMLSwift:
         )
         return self.access_url
 
-    def send_html(self, name, content: str):
+    def send_html(self, name, contentfile: str):
         conn = swiftclient.Connection(
             user=self.os_username,
             key=self.os_password,
@@ -86,7 +86,7 @@ class HTMLSwift:
                     log.info("Create bucket " + self.os_bucket + " successfully!")
 
         # upload file to Swift storage
-        with io.StringIO(content) as f:
+        with open(contentfile, "r") as f:
             if self.os_retention:
                 try:
                     conn.put_object(
@@ -122,9 +122,7 @@ class HTMLSwift:
                 self.send_html(name, html._generate_report(session))
                 session.config._report_url = self.get_access_url(name)
             except Exception as e:
-                log.error(
-                    f"Swift send_html error: {self.os_endpoint} - {e}"
-                )
+                log.error(f"Swift send_html error: {self.os_endpoint} - {e}")
 
     def pytest_terminal_summary(
         self,

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 
+from unittest import mock
 import pytest
 
 pytest_plugins = ["pytester"]
@@ -16,3 +17,13 @@ def set_env():
     del os.environ["OBJECT_STORAGE_BUCKET"]
     del os.environ["OBJECT_STORAGE_USERNAME"]
     del os.environ["OBJECT_STORAGE_PASSWORD"]
+
+
+@pytest.fixture
+def minio():
+    with mock.patch("pytest_html_object_storage.minio.Minio") as minio_mock, mock.patch(
+        "pytest_html_object_storage.minio.uuid"
+    ) as uuid_mock:
+        client_mock = mock.MagicMock()
+        minio_mock.return_value = client_mock
+        yield minio_mock, client_mock, uuid_mock

--- a/tests/test_pytest_minio.py
+++ b/tests/test_pytest_minio.py
@@ -1,17 +1,112 @@
 from _pytest.config import ExitCode
 from _pytest.pytester import RunResult
 
+import pytest
+
+from unittest import mock
+
 
 def run(pytester, *args):
-    return pytester.runpytest("--store-minio", *args)
+    return pytester.runpytest_inprocess("--store-minio", *args)
 
 
 class TestMinio:
-    def test_pass(self, pytester, set_env):
-        pytester.makepyfile("def test_pass(): pass")
-        result: RunResult = run(pytester)
+    @pytest.mark.parametrize(
+        "pytest_html_args", [None, "--html=test.html", "--self-contained-html"]
+    )
+    def test_no_pytest_html_params(self, pytester, pytest_html_args):
+        pytester.makepyfile(
+            """
+            def test_pass():
+              pass
+        """
+        )
+        result: RunResult = run(pytester, pytest_html_args)
+        assert result.ret == ExitCode.INTERNAL_ERROR
+        result.stderr.re_match_lines([".*--html.*--self-contained-html.*"])
+
+    def test_nominal(self, pytester, set_env, minio):
+        minio_mock, client_mock, uuid_mock = minio
+
+        uuid_mock.uuid4.return_value = "anuuid"
+        client_mock.bucket_exists.return_value = True
+        pytester.makepyfile(
+            """
+            def test_pass():
+              pass
+        """
+        )
+        result: RunResult = run(
+            pytester, "--html=test_report.html", "--self-contained-html"
+        )
         assert result.ret == 0
-        assert "HTML report sent on MinIO object storage at" in result.stdout.str()
+        minio_mock.assert_has_calls(
+            [
+                mock.call(
+                    "enm1n5rid50yi.x.pipedream.net",
+                    "admin",
+                    "password",
+                    region=None,
+                    secure=True,
+                ),
+                mock.call().bucket_exists("test"),
+                mock.call().fput_object(
+                    "test",
+                    "anuuid/report.html",
+                    "test_report.html",
+                    content_type="text/html",
+                ),
+            ]
+        )
+        result.stdout.re_match_lines(
+            [
+                ".*HTML report sent on MinIO object storage at https://enm1n5rid50yi.x.pipedream.net/test/anuuid/report.html.*"
+            ]
+        )
+
+    def test_create_bucket(self, pytester, set_env, minio):
+        minio_mock, client_mock, uuid_mock = minio
+
+        uuid_mock.uuid4.return_value = "anuuid"
+        client_mock.bucket_exists.return_value = False
+        pytester.makepyfile(
+            """
+            def test_pass():
+              pass
+        """
+        )
+        result: RunResult = run(
+            pytester, "--html=test_report.html", "--self-contained-html"
+        )
+        assert result.ret == 0
+        minio_mock.assert_has_calls(
+            [
+                mock.call(
+                    "enm1n5rid50yi.x.pipedream.net",
+                    "admin",
+                    "password",
+                    region=None,
+                    secure=True,
+                ),
+                mock.call().bucket_exists("test"),
+                mock.call().make_bucket("test"),
+                mock.call().set_bucket_policy(
+                    "test",
+                    """{"Version": "2012-10-17", "Id": "testPolicy", "Statement": [{"Sid": "Grant List and GET to everyone", "Effect": "Allow", "Principal": "*", "Action": ["s3:ListBucket", "s3:GetObject"], "Resource": ["test", "test/*"]}]}""",
+                ),
+                mock.call().fput_object(
+                    "test",
+                    "anuuid/report.html",
+                    "test_report.html",
+                    content_type="text/html",
+                ),
+            ]
+        )
+        result.stdout.re_match_lines(
+            [
+                ".*HTML report sent on MinIO object storage at https://enm1n5rid50yi.x.pipedream.net/test/anuuid/report.html.*"
+            ]
+        )
 
     def test_no_config(self, pytester):
         pytester.makepyfile("def test_no_config(): pass")


### PR DESCRIPTION
pytest-html-object-storage was doing calls to the private api of pytest-html v3, and this api has changed with the new version pytest-html v4.

This PR try to solve this issue by using a more public part of the api, i.e the command-line options of pytest-html.
